### PR TITLE
Aggiunto e modificato molte cose allo sprint0

### DIFF
--- a/sprint0/README.md
+++ b/sprint0/README.md
@@ -1,10 +1,8 @@
 # Sprint 0
 
 ## Indice
-
 - [Obiettivi](#obiettivi)
 - [Requisiti](#requisiti)
-- [Componenti Fornite](#componenti-fornite)
 - [Vocabolario](#vocabolario)
 - [Macrocomponenti](#macrocomponenti)
 - [Architettura di Riferimento](#architettura-di-riferimento)
@@ -13,161 +11,303 @@
 - [Team di Lavoro e Attività Specifiche](#team-di-lavoro-e-attività-specifiche)
 
 ## Obiettivi
-
 L'obiettivo prinicipale dello sprint 0 è analizzare i [requisiti](../requisiti/) forniti dal committente riguardo al progetto **TemaFinale25** eliminando eventuali ambiguità relative ai termini utilizzati e formalizzando quest'ultimi con dei componenti software (che possono essere già sviluppati o ancora da sviluppare).  
 
 Una volta formalizzati i requisiti si procederà con la definizione di una prima **architettura logica generale del sistema** che sarà il riferimento iniziale per lo sprint 1.  
+
 Questa architettura iniziale sarà costituita dai **macrocomponenti principali** (bounded context) deducibili dal documento dei requisiti, e dalle **interazioni** tra quest'ultimi sotto forma di messaggi (mappa di contesto).  
+
 L'architettura logica sarà anche corredata di un relativo piano di test iniziale.
 
 Terzo e ultimo obiettivo dello sprint 0 sarà quello di definire un **piano di lavoro** in cui si definirà il numero e gli obiettivi degli sprint necessari al completamento del sistema.  
+
 Inoltre, in questa sezione si deciderà come suddividere il lavoro tra i membri del gruppo, ed eventualmente, quali sprint potranno essere realizzati in parallelo.
 
-## INFO A CASO ???
+## INFO A CASO
 - disambuiguiamo i termini 
 - diciamo quali componenti sono da sviluppare
 - quali sono da formalizzare con un pezzo di software già in nostro possesso
 - cosa è un attore, cosa è un POJO, più eventuali attributi di entità
-- ricorda anche di formalizzare quelli che saranno i macrocomponenti del sistema
 - **pezzo relativo alla mappa e wenv praticamente da copiare e incollare**
 - ricorda di linkare alla repo del corso i progetti che si possono riciclare
 
 ## Requisiti
-
 I requisiti sono descritti dal committente nel documento: [documento dei requisiti](../requisiti/). 
 
-## Componenti Fornite
 
-Non tutte le componenti del sistema devono essere realizzate perchè sono fornite dal committente o perchè sono già a disposizione.  
-E' già disponibile il sensore Sonar.
-E' inoltre già disponibile il basicrobot, che dovrà essere esteso, come punto di partenza per il cargorobot.
-Il committente mette a disposizione il ???
 
 ## Vocabolario
-
 E' stato ritenuto più opportuno presentare i termini del dominio in un formato discorsivo, prolisso e ridondante, per garantire non solo che i termini non siano ambigui, ma anche che per il lettore sia difficile malinterpretare.
+
 Questo si contrappone al più comune approccio, in cui il vocabolario è un mero elenco puntato, nel quale è possibile che una mancata disambiguazione, possa evolvere in errori considerevoli durante lo sviluppo.
+
 Ci riserviamo la possibilità di ricondurci al classico vocabolario-elenco nel caso dovessero sorgere complicazioni inaspettate, sicuri del fatto che l'eventuale conversione sarà semplice.
 
-Un **Differential Drive Robot (DDR)** è un tipo di robot fisico e mobile che si muove grazie a due ruote motrici indipendenti, solitamente affiancate sullo stesso asse, che gli consentono di avanzare, arretrare o ruotare su sé stesso.
-"All'interno del sistema il DDR verrà utilizzato come supporto fisico per l'implementazione del _cargorobot_." 
 
-La **stiva (Hold)** rappresenta il workspace del robot: lo scenario entro cui è confinato ed in cui svolge i suoi **interventi di carico**.
-E' di forma rettangolare e sono presenti alcune aree notevoli e fisse che è bene segnalare con un nome univoco:
-- La **home** è la postazione da cui il robot parte e a cui il robot fa ritorno al termine di ogni intervento.
-- Gli **slots** sono le zone da cui il robot immagaiona i container. Sono 5 indicano le postazioni i cui il robot può depositare i container: da notare che il container numero 5 è sempre pieno e quindi in qualche modo si riduce ad un ostacolo. Ogni slot richiede che il robot sia adeguatamente orientato per immagazzinare: l'orientamente necessario cambia da uno slot ad un altro.
-- La **IO-Port** indica la posizione dove verranno depositati i container in arrivo, e dove quindi il cargorobot li andrà a prendere per poi spostarli. E' richesto che il robot sia rivolto verso il basso per prendere il container dall'**IO-port**.
 
-Si è detto che il deposito è l'area di lavoro del cargorobot: si noti, a tal proposito, il tentativo di descrivere il deposito, e gli elementi che lo compongono, inevitabilmente, conduce a una prima vaga descrizione dei processi che vi si svolgono (**interventi di carico**).
-Naturalmente, questo dipende dalla scelta, deliberata, di utilizzare gli elementi della stiva per descriverla.  
-Questo crea nella stiva una dipendenza forte dai suoi elementi, che riteniamo ragionevole, perchè non è particolarmente realistico, che una delle estensioni future preveda una stiva senza questi elementi notevoli al suo interno.
 
-Non sarebbe irragionevole immaginare di rappresentare la stiva come un POJO, ma si è scelto di interpretarla come un attore per i seguenti motivi:
-- Single Responsability Principle; il cargoservice si occupa della logica di buisness mentre la stiva gestisce la logica dei dati.
-- Uniformità rispetto al sistema in senso ampio.
+Un **_Differential Drive Robot (DDR)_** è un tipo di robot fisico e mobile che si muove grazie a due ruote motrici indipendenti, solitamente affiancate sullo stesso asse, che gli consentono di avanzare, arretrare o ruotare su sé stesso. All'interno del sistema il DDR è il supporto fisico che viene comandato dal _cargorobot_ per implementarne le azioni nel mondo reale. 
 
-La mappa della stiva è la seguente e l'origine del sistema di riferimento coincide con la home:
 
-```text
-    H , 1 , 1 , 1 , 1 , 1 , 1 , 
-    1 , S1, X , X , S2, 1 , 1 , 
-    1 , 1 , 1 , 1 , X , 1 , 1 , 
-    1 , S3, X , X , S4, 1 , 1 , 
-    1 , 1 , 1 , 1 , 1 , 1 , 1 , 
-    P , X , X , X , X , X , X , 
+
+
+Il **_deposito/stiva (Hold)_** rappresenta il workspace del _cargorobot_: lo scenario entro cui è confinato ed in cui svolge i suoi **interventi di carico**.
+
+È di forma rettangolare e sono presenti alcune aree notevoli e fisse che è bene segnalare con un nome univoco:
+- La **_home_** è la postazione da cui il _cargorobot_ parte e a cui il _cargorobot_ fa ritorno al termine di ogni intervento.
+- Gli **_slot_** sono le cinque postazioni in cui _container_ vengono depositati. Notare che **queste postazioni sono distinte dalle _laydown-positions_** siccome il _cargorobot_ scarica il _container_ che sta trasportando davanti a se. 
+    - I requisiti specificano che lo slot numero 5 è sempre occupato e quindi si riduce ad un ostacolo. 
+- Le **_laydown-position_** sono le postazioni in cui il _cargorobot_ si posiziona per effettuare l'operazione di deposito. Ogni _laydown-position_ è associata ad uno _slot_ e richiede che il _cargorobot_ sia orientato verso quest'ultimo per effettuare la sua operazione di deposito.  
+- La **_IO-Port_** indica la posizione dove verranno depositati i _container_ in arrivo. Similmente agli _slot_, alla _IO-port_ è associata una _pickup-position_ che ha una posizione distinta. 
+- La **_pickup-position_** è la postazione in cui il _cargorobot_ si posiziona per recuperare il _container_ arrivato alla _IO-Port_. Il _cargorobot_ deve essere rivolto verso _l'IO-port_ per caricare il _container_.
+
+Le aree appena elencate sono **attributi** dell'entità _deposito_ e possono essere modellate come POJO in quanto entità passive. Inoltre, il deposito ha come ulteriore attributo **_MaxLoad_** che definisce il peso massimo trasportabile dalla nave.
+
+Non sarebbe irragionevole immaginare di rappresentare il _deposito_ come un POJO che aggrega gli attributi appena descritti, ma si è ritenuto più opportuno modellarlo come un attore per **separare la logica dei dati dalla logica di buisness** (responsabilità di _cargoservice_) seguendo il Single Responsability Principle.
+
+Si è detto che il _deposito_ è l'area di lavoro del _cargorobot_: si noti, a tal proposito che il tentativo di descrivere il _deposito_, e gli elementi che lo compongono, inevitabilmente, conduce a una prima vaga descrizione dei processi che vi si svolgono (**interventi di carico**). Naturalmente, questo dipende dalla scelta, deliberata, di utilizzare gli elementi del _deposito_ per descriverlo. Questo crea nel _deposito_ una dipendenza forte dai suoi elementi, che riteniamo ragionevole, perchè non è particolarmente realistico, che una delle estensioni future preveda un _deposito_ senza questi elementi notevoli al suo interno.
+
+
+
+
+
+### NB: i requisiti sono ambigui nello specificare se la registrazione riguarda i singolo container o i prodotti come categoria (container diversi possono contenere lo stesso prodotto ma magari in quantità, e quindi peso, diverse). Bisogna chiedere al prof. per adesso ho lasciato l'opzione più probabile ovvero quella dei prodotti 
+Un **_container_** è un recipiente di dimensioni predefinite che contiene un determinato _prodotto_ da trasportare. Ogni **richiesta di carico** è sempre associata ad un container, e quest'ultimi vengono sempre recuperati dalla _IO-Port_ per poi essere trasportati dal _cargorobot_ dentro a uno degli _slot_ liberi.
+
+I **_prodotti_** sono merci di qualsiasi tipo sempre trasportate all'interno di un _container_. Ogni _prodotto_, viene sempre **registrato** dentro a _productservice_ prima di essere caricato. 
+
+**_productservice_** è un servizio utilizzato per registrare i _prodotti_ che devono essere caricati all'interno del _deposito_ dentro ad un database. L'operazione di registrazione consiste nello specificare il peso del prodotto da registrare, successivamente _productservice_ restituirà l'identificatore unico (PID) del prodotto appena registrato.
+
+Abbiamo quindi che un prodotto è una entità passiva modellabile come un POJO che ha come attributi:
+- un peso: valore reale
+- ed un PID: valore intero > 0
+
+Il committente fornisce già tutto il software necessario per l'implementazione di _productservice_ e dei _prodotti_. In particolare il componente che implementa le funzionalità di _productservice_ è un **attore** che si chiama (sfortunatamente) [cargoservice](./link). Questo è un nome infelice in quanto coincide con quello di un altro macrocomponente del sistema; da ora in poi ci si riferirà al software che il committente ha fornito con _productservice_.
+
+I messaggi con cui si può interagire con _productservice_ sono i seguenti.
+
+```
+    Request createProduct : product(String)                    
+    Reply   createdProduct: productid(ID) for createProduct   
+        
+    Request deleteProduct  : product( ID ) 
+    Reply   deletedProduct : product(String) for deleteProduct
+
+    Request getProduct : product( ID )  
+    Reply   getProductAnswer: product( JSonString ) for getProduct 
+    
+    Request getAllProducts : dummy( ID )
+    Reply   getAllProductsAnswer: products(  String ) for getAllProducts 
 ```
 
-Hold.H:   {(0, 0)}
-Hold.P:   {(0, 5), DOWN}
-Hold.S1:  {(1, 1), RIGHT}
-Hold.S2:  {(4, 1), LEFT}
-Hold.S3:  {(1, 3), RIGHT}
-Hold.S4:  {(4, 3), LEFT}
-Hold.X:   {(2, 1), (3, 1), (2, 3), (3, 3), (2, 4)}
-
-Un **container** è un entità associata ad ogni richiesta di **intervento di carico** del robot, che andrà spostata dalla IO-Port ad uno degli slot liberi, e che contiene **prodotti(o merci)**.
-Questi **prodotti** sono sempre all'interno di un container e sono caratterizzati da un peso e da un identificativo (pid > 0).
-Ogni prodotto è **registrato** prima di essere caricato. L'operazione di **registrazione** consiste semplicemente nell'inserimento delle caratteristiche del prodotto (ci si aspetta quindi, prevalentemente, prodotti industriali, prodotti in serie, sempre allo stesso modo, e non artigianali ed unici).
 
 
 
-#### Cargo Robot
-robot **logico** capace, **sotto richiesta**, di: muoversi liberamente all'interno del _deposito_, recuperare un container dall'_IO-port_, posizionare un container precendentemente recuperato in uno degli _slot_ liberi all'interno del _deposito_
+
+
+
+Un **_cargorobot_** è un robot **logico** capace, **sotto richiesta**, di: muoversi liberamente all'interno del _deposito_, recuperare un container dall'_IO-port_, posizionare un _container_ precendentemente recuperato in uno degli _slot_ liberi all'interno del _deposito_. È opportuno modellare il _cargorobot_ come **attore** in quanto è un componente attivo che ha un proprio flusso di controllo.
 
 **Il committente fornisce del software per la modellazione del _cargorobot_**. In particolare:
-- l'ambiente virtuale [WEnv](./sprint0.md) (aggiusta link) che simula la stiva di una nave in cui il _cargorobot_ dovrà operare
-- un componente software chiamato [basicrobot](./sprint0.md) (aggiusta link) che permette di governare un DDR virtuale all'interno di WEnv 
-    - c'è un leggero abstraction gap rispetto ai requisiti del cargorobot e quelli soddisfatti dal basicrobot. Il cargorobot deve anche saper:
-        - caricare un container per poi trasportarlo
-        - scaricare un container
-    - diventa quindi necessario estendere il basicrobot per implementare anche queste funzionalità.
+- l'ambiente virtuale [WEnv](./sprint0.md) (aggiusta link) che simula un _DDR_ e la _stiva_ della nave in cui il _cargorobot_ dovrà operare
+- un componente software chiamato [basicrobot](./sprint0.md) (aggiusta link) che permette di governare un _DDR_ virtuale all'interno di _WEnv_ 
 
-**dettagli WEnv**
-L'ambiente virtuale _WEnv_ modella la tipica stiva della nave in cui dovrà andare ad operare il _cargorobot_ e include un simulatore di DDR.
+L'ambiente virtuale **_WEnv_** modella la tipica stiva della nave in cui dovrà andare ad operare il _cargorobot_ e include un simulatore di _DDR_.
 
-Il DDR all'interno di WEnv è un robot inscrivibile in un cerchio di raggio R che può compiere solamente 4 mosse:
+Il _DDR_ all'interno di _WEnv_ è un **robot inscrivibile in un cerchio di raggio R** che può compiere solamente 4 mosse:
 - andare avanti per un certo periodo di tempo
 - andare indietro per un certo periodo di tempo
 - ruotare a destra di 90°
 - ruotare a sinistra di 90°
 
-Il committente fornisce poi il tempo necessario al DDR per andare avanti o indietro di una distanza pari alla sua dimensione.  
-Si ha quindi a disposizione anche una quinta mossa elementare chiamata **step** che corrisponde ad un passo del DDR lungo 2R.
-Il committente ha anche specificato che lo step fornisce un unità di misura per misurare le dimensioni del deposito.
-In assenza meccanismi per la misurazione delle distanze nel deposito, si considera come unità spaziale la dimensione fisica R del cargorobot fornito dal committente, misurabile in step di durata fissata.
+Il committente fornisce il tempo necessario al DDR per andare avanti o indietro di **una distanza pari alla sua dimensione**. Si ha quindi a disposizione anche una quinta mossa elementare chiamata **step** che corrisponde ad un passo del DDR lungo 2R.
+
+Il committente ha anche specificato che lo **step fornisce un unità di misura per le dimensioni del deposito**. Il deposito pertanto può essere modellato come una **griglia rettangolare composto da HHxHW (Hold Height per Hold Width) celle**. Ogni cella è un quadrato con lato pari all'unità di misura robotica, ovvero 2R. 
+
+Basandosi sull'unità di misura robotica, il committente fornisce anche una mappa del _deposito_ (utilizzata dal _basicrobot_) e le coordinate di tutte le aree notevoli al suo interno. L'origine del sistema di riferimento è l'angolo in alto a sinistra che coincide con la _home_.
+
+In seguito la mappa fornita dal committente e le coordinate delle posizioni notevoli. Nella mappa:
+- gli '1' indicano una cella libera
+- le 'X' indicano un ostacolo
+- la 'r' indica la posizione del robot
+
+```
+    r,  1,  1,  1,  1,  1,  1, 
+    1,  1,  X,  X,  1,  1,  1, 
+    1,  1,  1,  1,  X,  1,  1, 
+    1,  1,  X,  X,  1,  1,  1, 
+    1,  1,  1,  1,  1,  1,  1, 
+    X,  X,  X,  X,  X,  X,  X, 
+```
+// non c'è bisogno di indicare il direzionamento in quanto ho specificato sopra
+- Home:              Hold.Home = (0,0)
+- Slots:             Hold.Slots = {(2,1), (3,1), (2,3), (3,3), (4,2)}
+- Laydown-positions: Hold.LaydownPositions = {(1,1), (1,3), (4,1), (4,3)}
+- IO-port:           Hold.IoPort = (0,5)
+- Pickup-position:   Hold.PickupPosition = (0,4)
+
+Indicando nella mappa fornita le coordinate specificate otteniamo la seguente mappa logica.
+
+```text
+    H,  1,  1,  1,  1,  1,  1, 
+    r,  L1, S1, S2, L2, 1,  1, 
+    1,  1,  1,  1,  S5, 1,  1, 
+    1,  L3, S3, S4, L4, 1,  1, 
+    P,  1,  1,  1,  1,  1,  1, 
+    IO, X,  X,  X,  X,  X,  X,   
+```
+
 
 ![Wenv](../requisiti/scene.jpg)
 
-**dettagli basicrobot**
-Il robot è un oggetto di dimensioni finite, inscrivibile in un cerchio di diametro D (unità robotica) ed esegue movimenti a velocità costante.
-Il basicrobot fornito dal committente è un puro esecutore di comandi, con cui il robot può effettuare singole mosse o sequenze di mosse, a seguito di messaggi di richiesta.
+
+Il **_basicrobot_** fornito dal committente è un **attore** esecutore di comandi con cui è possibile governare il _DDR_ all'interno di _WEnv_. Il _basicrobot_ modella quindi un _DDR_ e permette di effettuare singole mosse o **sequenze di mosse**, a seguito di messaggi di richiesta. Più nel dettaglio, il basicrobot incorpora un **planner** grazie al quale è in grado di produrre la sequenza di mosse necessarie per posizionare il _DDR_ a una determinata coordinata, con un preciso direzionamento.
+
+In seguito, i messaggi con cui è possibile interagire con il _basicrobot_.
+
 ```
-listone messaggi con cui si può interagire con il basicrobot 
+    Dispatch cmd       	: cmd(MOVE)         
+    Dispatch end       	: end(ARG)         
+    
+    Request step       : step(TIME)	
+    Reply stepdone     : stepdone(V)                 for step
+    Reply stepfailed   : stepfailed(DURATION, CAUSE) for step
+
+    Event  sonardata   : sonar( DISTANCE ) 	   
+    Event obstacle     : obstacle(X) 
+    Event info         : info(X)    
+
+    Request  doplan     : doplan( PATH, STEPTIME )
+    Reply doplandone    : doplandone( ARG )    for doplan
+    Reply doplanfailed  : doplanfailed( ARG )  for doplan
+
+    Dispatch setrobotstate: setpos(X,Y,D) //D =up|down!left|right
+
+    Request engage        : engage(OWNER, STEPTIME)	
+    Reply   engagedone    : engagedone(ARG)    for engage
+    Reply   engagerefused : engagerefused(ARG) for engage
+
+    Dispatch disengage    : disengage(ARG)
+
+    Request checkowner    : checkowner(CALLER)
+    Reply checkownerok    : checkownerok(ARG)      for checkowner
+    Reply checkownerfailed: checkownerfailed(ARG)  for checkowner
+    
+    Event alarm           : alarm(X)
+    Dispatch nextmove     : nextmove(M)
+    Dispatch nomoremove   : nomoremove(M)
+    
+    Dispatch setdirection : dir( D )  //D =up|down!left|right
+
+    //Inglobamento endosimbitico di robotpos
+    Request moverobot    :  moverobot(TARGETX, TARGETY)  
+    Reply moverobotdone  :  moverobotok(ARG)                    for moverobot
+    Reply moverobotfailed:  moverobotfailed(PLANDONE, PLANTODO) for moverobot
+    
+    //Richieste di info 
+    Request getrobotstate : getrobotstate(ARG)
+    Reply robotstate      : robotstate(POS,DIR)  for getrobotstate
+
+    Request getenvmap     : getenvmap(X)
+    Reply   envmap        : envmap(MAP)  for getenvmap
 ```
 
-Product Service
-- si interfaccia con un database
-holdservice
-attore 
-Sonar Sensor
-- put in front of the io-port
-- used to detect the presence of a product container when it measures a distance D, such that D < DFREE/2, during a reasonable time (e.g. 3 secs).
-sonarservice
-- attore in quanto ente attivo, che osserva le misurazioni per 3 secondi e successivamente aggiorna i suoi clienti
-Cargoservice
-- macrocomponente core buisness del sistema
-- Fa da orchestrare.
-- riceve le richieste di carico
-    - sotto determinate condizioni le rifiuta
+Vi è un **abstraction gap** tra i requisiti del _cargorobot_ e quelli soddisfatti dal _basicrobot_; quest'ultimo **non è in grado caricare/scaricare container**. Il committente ha però specificato che nel sistema da sviluppare sarà sufficiente essere in grado di muovere il _DDR_ virtuale dentro a _WEnv_, **le operazioni di carico e scarico dei container di _cargorobot_ possono essere ridotte a delle stampe o noop**. Il _basicrobot_ fornito è quindi sufficiente nonostante non sia in grado di caricare/scaricare container per limitazione dell'ambiente virtuale _WEnv_.
 
-Infine la **dynamically updated web GUI** è la pagina web che mostra graficamente, in tempo reale, lo stato del deposito. Si noti che non è previsto di poter visualizzare i container, ne le informazioni relative ai prodotti al loro inerno.
+Si noti a questo proposito la relazione tra i componenti _cargorobot_ e _basicrobot_. _cargorobot_ risulta essere un componente **interfaccia** che permette al resto del sistema di pilotare un DDR robot. Il _basicrobot_ risulta essere una **implementazione** di questa interfaccia con cui si pilota la specifica tipologia di _DDR_ simulata da _WEnv_. In una futura estensione del sistema, se si desidererà sostituire _WEnv_ con un _DDR_ reale (con cui si può anche ), sarà sufficiente progettare un nuovo componente in grado di comandare gli attuatori di questo _DDR_ rispettando l'interfaccia imposta da _cargorobot_. Successivamente, bisognerà modificare _cargorobot_ in modo tale che utilizzi questo nuovo componente come implementazione della sua interfaccia al posto di _basicrobot_. **Il resto del sistema rimarrà invariato** ma in questo modo funzionerà anche nel mondo fisico e non solo in quello virtuale. 
 
-## Macrocomponenti
+Per questi motivi, sara fondamentale prevedere nel _cargorobot_ anche le operazioni di carico/scarico dei container anche se non sarà necessario implementarle.
 
-Il sistema deve essere distribuito su N nodi computazionali diversi???
 
-Segue l'elenco dei macrocomponenti software da sviluppare:
+
+
+
+
+
+Il **_Sonar_** è un componente attivo che, tenendo traccia delle misurazioni periodiche che effettua, è in grado di rilevare la presenza o l'assenza di un _container_ presso l'_IO-port_. In quanto componente attivo è opportuno modellare il _sonar_ con un **attore**. 
+
+Il _sonar_ è infine caratterizzato da una costante chiamata **_DFREE_** che definisce:
+- la distanza massima con cui una misurazione può essere interpretata: "come assenza di container" (DFREE/2)
+- la distanza massima con cui una misurazione può essere considerata valida (DFREE)
+
+Siccome _DFREE_ rappresenta una distanza è opportuno modellarlo come un valore rele maggiore di zero.
+
+Un componente strettamente associato al _sonar_ è il **_Led_**. I requisiti speicificano che in caso di misurazioni del _sonar_ riconducibili a malfunzionamenti di quest'ultimo, il led **deve essere acceso da _cargoservice_** in modo da notificare la presenza del malfunzionamento. Questo è un comportamento **passivo** e pertanto modellabile tramite un POJO. Tuttavia, siccome è presumibile che il led fisico da accendere risieda in un nodo fisico distinto rispetto a quello di _cargoservice_, è più opportuno modellare _led_ come un **attore** parte di un sistema distribuito.   
+
+
+
+
+
+Il **_Cargoservice_** è il macrocomponente principale che implementa il core-buisness del sistema. Si occupa di orchestrare gli altri componenti del sistema per decidere:
+- se accettare o rifiutare una richiesta di carico
+- quale slot libero associare alla richiesta che si sta servendo
+- dove e quando spostare il _cargorobot_
+- di interrompere tutte le attività quando si accorge di un malfunzionamento del _sonar_
+
+Modellare il cargoservice come **attore** è ancora più opportuno rispetto ai casi precedenti in quanto oltre ad essere un componente attivo, è anche un componente **reattivo** agli eventi del _sonar_.
+
+
+// bisogna capire che cosa intende il prof con stato del deposito
+Infine, la **dynamically updated web GUI** è la pagina web che mostra graficamente e in tempo reale, lo stato del deposito. Si noti che non è previsto di poter visualizzare i container, ne le informazioni relative ai prodotti al loro inerno.
+
+
+
+
+
+
+
+
+
+## Macrocomponenti (la roba tra parentesi quadre serve solo per fare mente locale, non va lasciata)
+//Il sistema deve essere distribuito su N nodi computazionali diversi???
+(Proposta:
+potenzialmente ognuno dei macrocomponenti del sistema può essere distribuito su un nodo fisico distinto, tuttavia, decidere il grado di distribuzione del sitema durante lo sprint 0 risulta prematuro, per questo motivo si rimanda questa decisione dopo aver effettuato le analisi del problema nei prossimi sprint.
+
+Fanno eccezione i componenti che modellano un'entità reale, il deployment di quest'ultimi va per forza effettuato sul nodo fisico in cui sono presenti i sensori/attuatori da comandare. Per questo motivo si può già dallo sprint 0 affermare che _sonar_ e _led_ risiederanno su un nodo fisico distinto rispetto al resto del sistema (anche lo stesso). 
+
+In futuro, anche il componente che comanderà il _DDR_ fisico (sostituendo l'attuale _basicrobot_) dovrà per gli stessi motivi essere distribuito su un nodo fisico a se stante.
+)
+
+
+Segue l'elenco dei macrocomponenti software del sistema:
 
 - cargoservice (orchestratore che comunica con praticamente tutti)
-    - riceve eventi riguardo alla presenza/assenza di container da sonarservice
-    - manda query a product service per recuperare il peso del prodotto da caricare
-    - comunica con holdservice per recuperare il prossimo slot libero e per occuparlo
+    - [riceve eventi riguardo alla presenza/assenza di container da sonarservice]
+    - [manda query a product service per recuperare il peso del prodotto da caricare]
+    - [comunica con holdservice per recuperare il prossimo slot libero e per occuparlo]
 - productservice
-    - registra i prodotti
-    - riceve richieste di registrazione da clienti esterni al sistema
-    - riceve query da cargoservice per recuperare il peso relativo ad un prodotto che deve caricare
-- sonarservice
-    - invia aggiornamento sulla presenza o meno del container al cargoservice
-- holdservice
-    - comunica con cargoservice per fornire il prossimo slot libero e per aggiornare il suo stato  
+    - [registra i prodotti]
+    - [riceve richieste di registrazione da clienti esterni al sistema]
+    - [riceve query da cargoservice per recuperare il peso relativo ad un prodotto che deve caricare]
+- cargorobot
+- basicrobot
+- WEnv
+- sonar 
+    - [invia aggiornamento sulla presenza o meno del container al cargoservice]
+- led
+    - [viene acceso da cargoservice quando il sonar emette una evento riconducibile ad un malfunzionamento]
+- hold
+    - [comunica con cargoservice per fornire il prossimo slot libero e per aggiornare il suo stato  ]
 - web-gui
-    - riceve gli aggiornamenti sullo stato del deposito da holdservice
+    - [riceve gli aggiornamenti sullo stato del deposito da holdservice]
+
+
+quelli da sviluppare sono:
+- cargoservice
+- cargorobot
+- sonar
+- led
+- hold
+- webgui
+
 
 ## Architettura di Riferimento
 
 ### Messaggi
-
 I messaggi costituiscono la base fondamentale della comunicazione nel modello distribuito ad attori adottato.  
+
+I requisiti non specificano la maggior parte delle interazioni tra i componenti del sistema, di conseguenza ci si limita definire solamente i messaggi che modellano le interazioni espresse esplicitamente. Le interazioni rimanenti verranno discusse e modellate durante le fasi di analisi del problema nei successivi sprint.  
+
 
 ```text
     <inserire qui request e response>
@@ -210,13 +350,13 @@ Scenario di test 5: richiesta di intervento di carico rifiutata a causa del peso
 
 Oltre a questo sprint 0 iniziale, dedicato all'impostazione del progetto, nel nostro processo Scrum abbiamo previsto tre sprint operativi:
 1. Sprint 1
-    - estensione del basicrobot per implementare le operazioni mancanti necessarie al cargorobot
     - cargoservice (corebuisness del sistema)
+    - cargorobot
 1. Sprint 2
-    - sonarservice
-    - holdservice
+    - sonar
+    - hold
 1. Sprint 3
-    - productservice
+    - led
     - web-gui
 
 | Numero sprint             | Data inizio (indicativa)  | Data fine (indicativa)    | Lavoro Stimato Totale (h) |


### PR DESCRIPTION
Nell'incominciare a pensare alla definizione delle "scatole vuote" per l'architettura logica generale, mi sono accorto che lo sprint0 attuale non andava molto bene.

Ecco la lista dei cambiamenti che ho fatto:
- usato i termini del vocabolario e non termini generici (es: 'cargorobot' al posto di 'robot')
- distinto tra posizioni in cui il cargorobot si posiziona per effettuare le sue operazioni, e posizioni degli slot/io-port
- spostato la mappa nella sezione di WEnv in cui specifico l'unità di misura e come sono fatte le celle
- distinto tra mappa fornita dal committente, e quella logica con le posizioni notevoli segnate
- tolto la distinzione nel vocabolario tra holdservice e hold, sonarservice e sonar in quanto si uscirebbe dall'analisi dei requisiti e si entrerebbe già in una parte più simile all'analisi del problema (si sta già affermando che il sonar è un servizio quando nei requisiti non c'è scritto da nessuna parte) 
- aggiustato la definizione di container
- spostato il termine PID dentro a productservice in quanto i requisiti specificano che è questo servizio a generare questo numero
- specificato direttamente nel vocabolario quali componenti sono già forniti dal committente togliendo la sezione specifica
- aggiunto il componente led che mancava
- aggiustata la lista dei componenti distinguendo tra quelli che compongono il sistema e quelli che dobbiamo sviluppare
-  messo degli spazi in giro per il readme per renderlo più leggibile (per me). Non si vedono quando si fa il render.


Chiedo scusa per i troppi cambiamenti in un'unica pull request. Mi sono lasciato andare... 